### PR TITLE
fix: move commit pins to proper section

### DIFF
--- a/hyprpm.toml
+++ b/hyprpm.toml
@@ -1,10 +1,6 @@
-[Hypr-DarkWindow]
-description = "Invert the colors of specific Windows"
+[repository]
+name = "Hypr-DarkWindow"
 authors = ["micha4w"]
-output = "out/hypr-darkwindow.so"
-build = [
-    "make all",
-]
 commit_pins = [
     # v Hyprland                                  v Hypr-DarkWindow
     ["1c460e98f870676b15871fe4e5bfeb1a32a3d6d8", "7eb7e04dea8cb92f22b7c2df4c78d4f29e28643d"], # v0.36.0
@@ -18,4 +14,12 @@ commit_pins = [
     ["ea2501d4556f84d3de86a4ae2f4b22a474555b9f", "d1c4337676d618db7199e4717c59807b4cafac5e"], # v0.41.0
     ["9e781040d9067c2711ec2e9f5b47b76ef70762b3", "ad5cb981f801e32b576617ec9290c282304c30d4"], # v0.41.1
     ["9a09eac79b85c846e3a865a9078a3f8ff65a9259", "58bb4f967c58334a1d6dbe0ab2442ac8984d2ac6"], # v0.42.0
+]
+
+[Hypr-DarkWindow]
+description = "Invert the colors of specific Windows"
+authors = ["micha4w"]
+output = "out/hypr-darkwindow.so"
+build = [
+    "make all",
 ]


### PR DESCRIPTION
I have just found out that the commit pins (which I have introduced in #2) were in the wrong spot in the manifest the whole time. I'm so sorry about that!

For some background, `hyprpm` reads them from the `repository` section, not the individual plugin sections. As seen in the [hyprpm source](https://github.com/hyprwm/Hyprland/blob/3b4aabe04c7756fb0a70d78b6f0e701228f46345/hyprpm/src/core/Manifest.cpp#L57-L64).

So before this fix, `hyprpm` would just ignore it, as seen in no mention of them in the output:
![image](https://github.com/user-attachments/assets/a22dea7c-64ad-4ff0-8672-dbffa542bbfc)

After this fix, they seem to be found correctly:
![image](https://github.com/user-attachments/assets/3bdad790-7c9c-4246-8158-ede49957740f)
