### PR TITLE
Fix build on -git

### DIFF
--- a/src/DecorationsWrapper.h
+++ b/src/DecorationsWrapper.h
@@ -14,7 +14,7 @@ public:
         return std::move(m_Wrapped);
     }
 
-    virtual void draw(CMonitor* m, float a) {
+    virtual void draw(PHLMONITOR m, float a) {
         m_Inverter.SoftToggle(false);
         m_Wrapped->draw(m, a);
         m_Inverter.SoftToggle(true);


### PR DESCRIPTION
With the recent addition of the DecorationsWrapper, the plugin does no longer build on -git. The reason being that hyprland has migrated from raw monitor pointers to shared pointers (https://github.com/hyprwm/Hyprland/commit/f044e4c9514ec89c4c1fc8a523ca90b8cb907fb7). The fix is to also migrate to those.

As we already have a (now working) commit pin for 0.41.1 with the new DecoWrapper, this should not break anything on the current latest release.