### PR TITLE
add CM stub shader

### DIFF
--- a/src/Helpers.cpp
+++ b/src/Helpers.cpp
@@ -11,7 +11,37 @@ void ShaderHolder::Init()
 {
     g_pHyprRenderer->makeEGLCurrent();
 
-    GLuint prog               = CreateProgram(TEXVERTSRC, TEXFRAGSRCRGBA_DARK);
+    GLuint prog               = CreateProgram(TEXVERTSRC, TEXFRAGSRCCM_DARK);
+    CM.program                = prog;
+    CM.proj                   = glGetUniformLocation(prog, "proj");
+    CM.tex                    = glGetUniformLocation(prog, "tex");
+    CM.texType                = glGetUniformLocation(prog, "texType");
+    CM.sourceTF               = glGetUniformLocation(prog, "sourceTF");
+    CM.targetTF               = glGetUniformLocation(prog, "targetTF");
+    CM.sourcePrimaries        = glGetUniformLocation(prog, "sourcePrimaries");
+    CM.targetPrimaries        = glGetUniformLocation(prog, "targetPrimaries");
+    CM.maxLuminance           = glGetUniformLocation(prog, "maxLuminance");
+    CM.dstMaxLuminance        = glGetUniformLocation(prog, "dstMaxLuminance");
+    CM.dstRefLuminance        = glGetUniformLocation(prog, "dstRefLuminance");
+    CM.sdrSaturation          = glGetUniformLocation(prog, "sdrSaturation");
+    CM.sdrBrightness          = glGetUniformLocation(prog, "sdrBrightnessMultiplier");
+    CM.alphaMatte             = glGetUniformLocation(prog, "texMatte");
+    CM.alpha                  = glGetUniformLocation(prog, "alpha");
+    CM.texAttrib              = glGetAttribLocation(prog, "texcoord");
+    CM.matteTexAttrib         = glGetAttribLocation(prog, "texcoordMatte");
+    CM.posAttrib              = glGetAttribLocation(prog, "pos");
+    CM.discardOpaque          = glGetUniformLocation(prog, "discardOpaque");
+    CM.discardAlpha           = glGetUniformLocation(prog, "discardAlpha");
+    CM.discardAlphaValue      = glGetUniformLocation(prog, "discardAlphaValue");
+    CM.topLeft                = glGetUniformLocation(prog, "topLeft");
+    CM.fullSize               = glGetUniformLocation(prog, "fullSize");
+    CM.radius                 = glGetUniformLocation(prog, "radius");
+    CM.roundingPower          = glGetUniformLocation(prog, "roundingPower");
+    CM.applyTint              = glGetUniformLocation(prog, "applyTint");
+    CM.tint                   = glGetUniformLocation(prog, "tint");
+    CM.useAlphaMatte          = glGetUniformLocation(prog, "useAlphaMatte");
+
+    prog                      = CreateProgram(TEXVERTSRC, TEXFRAGSRCRGBA_DARK);
     RGBA.program              = prog;
     RGBA.proj                 = glGetUniformLocation(prog, "proj");
     RGBA.tex                  = glGetUniformLocation(prog, "tex");
@@ -72,6 +102,7 @@ void ShaderHolder::Destroy()
 {
     g_pHyprRenderer->makeEGLCurrent();
 
+    CM.destroy();
     RGBA.destroy();
     RGBX.destroy();
     EXT.destroy();

--- a/src/Helpers.h
+++ b/src/Helpers.h
@@ -25,6 +25,7 @@ namespace std
 
 struct ShaderHolder
 {
+    CShader CM;
     CShader RGBA;
     CShader RGBX;
     CShader EXT;

--- a/src/TexturesDark.h
+++ b/src/TexturesDark.h
@@ -17,6 +17,21 @@ void invert(inout vec4 color) {
 )glsl";
 
 
+inline const std::string TEXFRAGSRCCM_DARK = R"glsl(
+precision highp float;
+varying vec2 v_texcoord;
+uniform sampler2D tex;
+
+)glsl" + DARK_MODE_FUNC + R"glsl(
+
+void main() {
+    vec4 pixColor = texture2D(tex, v_texcoord);
+
+    invert(pixColor);
+
+    gl_FragColor = pixColor;
+})glsl";
+
 inline const std::string TEXFRAGSRCRGBA_DARK = R"glsl(
 precision highp float;
 varying vec2 v_texcoord; // is in 0-1

--- a/src/WindowInverter.cpp
+++ b/src/WindowInverter.cpp
@@ -16,6 +16,7 @@ void WindowInverter::OnRenderWindowPre(PHLWINDOW window)
         std::swap(m_Shaders.EXT, g_pHyprOpenGL->m_RenderData.pCurrentMonData->m_shEXT);
         std::swap(m_Shaders.RGBA, g_pHyprOpenGL->m_RenderData.pCurrentMonData->m_shRGBA);
         std::swap(m_Shaders.RGBX, g_pHyprOpenGL->m_RenderData.pCurrentMonData->m_shRGBX);
+        std::swap(m_Shaders.CM, g_pHyprOpenGL->m_RenderData.pCurrentMonData->m_shCM);
         m_ShadersSwapped = true;
     }
 }
@@ -27,6 +28,7 @@ void WindowInverter::OnRenderWindowPost()
         std::swap(m_Shaders.EXT, g_pHyprOpenGL->m_RenderData.pCurrentMonData->m_shEXT);
         std::swap(m_Shaders.RGBA, g_pHyprOpenGL->m_RenderData.pCurrentMonData->m_shRGBA);
         std::swap(m_Shaders.RGBX, g_pHyprOpenGL->m_RenderData.pCurrentMonData->m_shRGBX);
+        std::swap(m_Shaders.CM, g_pHyprOpenGL->m_RenderData.pCurrentMonData->m_shCM);
         m_ShadersSwapped = false;
     }
 }
@@ -58,6 +60,7 @@ void WindowInverter::Unload()
         std::swap(m_Shaders.EXT, g_pHyprOpenGL->m_RenderData.pCurrentMonData->m_shEXT);
         std::swap(m_Shaders.RGBA, g_pHyprOpenGL->m_RenderData.pCurrentMonData->m_shRGBA);
         std::swap(m_Shaders.RGBX, g_pHyprOpenGL->m_RenderData.pCurrentMonData->m_shRGBX);
+        std::swap(m_Shaders.CM, g_pHyprOpenGL->m_RenderData.pCurrentMonData->m_shCM);
         m_ShadersSwapped = false;
     }
 


### PR DESCRIPTION
This fixes the plugin after color management was added in https://github.com/hyprwm/Hyprland/commit/8c97cb7858e5d6c35d1a055930904346fb4248db

This probably bypasses color management for inverted windows, but this should be good enough for now.