### PR TITLE
Support Array type arguments

### DIFF
--- a/src/Helpers.cpp
+++ b/src/Helpers.cpp
@@ -75,11 +75,11 @@ Uniforms ShaderDefinition::ParseArgs(const std::string& args)
         {
             bool first = c>='a' && c<='z' || c>='A' && c<='Z' || c=='_';
             bool other = c>='0' && c<='9';
+            bool special = c == '[' || c == ']' || c == '.';
 
-            if (!(first || other && i != 0))
+            if (!(first || ((other || special) && i != 0)))
                 throw efmt("invalid shader uniform name '{}'", name);
         }
-
         ss >> std::ws;
         
         std::vector<float> values;


### PR DESCRIPTION
This can be useful at cases like: https://github.com/micha4w/Hypr-DarkWindow/issues/26

### Example usage:
A shader with array arguments.
```glsl
#define MAX_COLORS 16

uniform float count; 

uniform vec3 bkg[MAX_COLORS];
uniform float similarity[MAX_COLORS];
uniform float amount[MAX_COLORS];
uniform float targetOpacity[MAX_COLORS];

bool isColorSimilar(vec3 color, vec3 target, float sim) {
    return color.r >= target.r - sim && color.r <= target.r + sim &&
           color.g >= target.g - sim && color.g <= target.g + sim &&
           color.b >= target.b - sim && color.b <= target.b + sim;
}

void windowShader(inout vec4 color) {
    int loopCount = int(count);
    
    if (loopCount > MAX_COLORS) loopCount = MAX_COLORS;

    for (int i = 0; i < MAX_COLORS; i++) {
        if (i >= loopCount) break;

        vec3 currentBkg = bkg[i];
        float currentSim = similarity[i];
        
        if (isColorSimilar(color.rgb, currentBkg, currentSim)) {
            float currentAmt = amount[i];
            float currentOp = targetOpacity[i];

            vec3 error = abs(color.rgb - currentBkg);
            float avg_error = (error.r + error.g + error.b) / 3.0;

            float factor = currentOp + (1.0 - currentOp) * avg_error * currentAmt / currentSim;
            
            color *= factor;
            break; 
        }
    }
}
```

hyprland config
```
darkwindow:shader[custom_chromakey_vscode] {
    path = /home/shinkuan/Documents/DarkWindowShader/multi_chromakey.frag
    introduces_transparency = true
    args = count=2 bkg[0]=[0.12109375 0.12109375 0.12109375] similarity[0]=0.003 amount[0]=1 targetOpacity[0]=0.75 bkg[1]=[0.09375 0.09375 0.09375] similarity[1]=0.003 amount[1]=1 targetOpacity[1]=0.8
}
windowrulev2 = plugin:shadewindow custom_chromakey_vscode, class:^(code)$
```
Now supports arguments like: `bkg[0]`