### PR TITLE
feat: add time uniform support to shaders

### DIFF
--- a/src/Helpers.h
+++ b/src/Helpers.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <chrono>
+#include <format>
 #include <string>
 #include <cstring>
+#include <stdexcept>
 
 #include <hyprland/src/render/Renderer.hpp>
 #include <hyprland/src/config/ConfigManager.hpp>
@@ -65,6 +68,7 @@ struct ShaderHolder
 {
     std::map<std::string, std::array<GLint, 4>> UniformLocations;
 
+    std::array<GLint, 4> TimeLocations;
     SShader CM;
     SShader RGBA;
     SShader RGBX;


### PR DESCRIPTION
I've been playing around with this repo and just wanted to say thank you for making such a cool plugin!

I thought it would be very nice to have dynamic shaders that can change based on time, so I implemented a `time` uniform to support this.

**Implementation:**
The shader now accepts a `time` input. When used, it triggers a redraw for the window to allow animations to play.

**Example Usage:**

A shader that takes time uniform arg.
```glsl
uniform float time;

void windowShader(inout vec4 color) {
    vec3 sineColor = 0.5 + 0.5 * cos(time + vec3(0, 2, 4));
    color.rgb = mix(color.rgb, sineColor, 0.3); 
}
```

Some further testing might be needed to check for bugs.

Showcase:

https://github.com/user-attachments/assets/259e6822-e2d1-48db-9cca-929edf50aef9

https://github.com/user-attachments/assets/b4ca97fd-b4a6-41a7-becf-827a8fdcc7ac

